### PR TITLE
disableScrollLockIfAtBottom can set scroll lock

### DIFF
--- a/lib/views/process-output-view.coffee
+++ b/lib/views/process-output-view.coffee
@@ -85,8 +85,6 @@ class ProcessOutputView extends View
       # Only do this while the process is running.
       if (@outputPanel.scrollTop() > 0)
         @setScrollLockEnabled(false);
-    else
-      @setScrollLockEnabled(true);
 
   parentHeightChanged: (parentHeight) ->
     @calculateHeight();


### PR DESCRIPTION
`disableScrollLockIfAtBottom` should never _set_ scroll lock, only conditionally _unset_ it

This fixes an issue where streaming output can cause scroll lock to enable itself, presumably due to the condition on line 84 failing.
