### PR TITLE
Add output sanitizer: escape HTML & convert ANSI escape sequences

### DIFF
--- a/lib/views/process-output-view.coffee
+++ b/lib/views/process-output-view.coffee
@@ -2,6 +2,8 @@ _ = require 'underscore-plus'
 {$$, View} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'atom'
 ButtonsView = require './buttons-view'
+escapeHTML = require 'underscore.string/escapeHTML'
+ANSIConvert = new (require 'ansi-to-html')
 
 module.exports =
 class ProcessOutputView extends View
@@ -146,6 +148,7 @@ class ProcessOutputView extends View
     @refreshScrollLockButton();
 
   outputToPanel: (text) ->
+    text = sanitizeOutput(text);
     addNewLine = false;
 
     for line in text.split('\n')
@@ -166,3 +169,11 @@ class ProcessOutputView extends View
 
   getElement: ->
     return @element;
+
+  sanitizeOutput = (output) ->
+    # Prevent HTML in output from being parsed as HTML
+    output = escapeHTML(output);
+    # Convert ANSI escape sequences (ex. colors) to HTML
+    output = ANSIConvert.toHtml(output);
+
+    return output

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "minimatch": "^2.0.10",
     "shelljs": "0.5.3",
     "path": "^0.11.14",
-    "ps-tree": "1.0.0"
+    "ps-tree": "1.0.0",
+    "underscore.string": "~3.2",
+    "ansi-to-html": "~0.3"
   }
 }


### PR DESCRIPTION
## Summary

Adds an output "sanitizer" function to escape HTML and convert ANSI escape sequences to HTML.
## Screenshots
### HTML escaping
#### Before

<img width="221" alt="before_html" src="https://cloud.githubusercontent.com/assets/544541/11254459/d371c44a-8e0e-11e5-8096-af7d7ad035bf.png">
#### After

_In my specific case, it was an HTML-like sequence, not HTML:_

<img width="334" alt="after_html" src="https://cloud.githubusercontent.com/assets/544541/11254479/eb91496a-8e0e-11e5-9cbd-d7fc59553fbe.png">
### ANSI escape sequences
#### Before

<img width="286" alt="before_ansi" src="https://cloud.githubusercontent.com/assets/544541/11254481/f025eb0c-8e0e-11e5-8abe-0b77f0794066.png">
#### After

<img width="227" alt="after_ansi" src="https://cloud.githubusercontent.com/assets/544541/11254484/f52000c0-8e0e-11e5-8407-7921d7d6ec5a.png">
## Notes

Thanks for this helpful package, @morassman! Of course, please feel free to take/leave anything you'd like. 
