### PR TITLE
Update config-controller to determine filePath from Pane, rather than Editor

### DIFF
--- a/lib/controllers/config-controller.coffee
+++ b/lib/controllers/config-controller.coffee
@@ -65,10 +65,10 @@ class ConfigController
 
   runProcess: =>
     filePath = null;
-    editor = atom.workspace.getActiveTextEditor();
+    pane = atom.workspace.getActivePaneItem();
 
-    if editor?
-      filePath = editor.getPath();
+    if pane?
+      filePath = pane.getPath();
 
     @runProcessWithFile(filePath);
 


### PR DESCRIPTION
Change runProcess to use Panes rather than TextEditor, allowing the filePath to be obtained from all types of windows.

By making this change, we can now run process-palette on (among others) pdf-view windows such as attaching the pdf to an email.
