### PR TITLE
Do not unset selection if filePath is none

### DIFF
--- a/lib/controllers/process-controller.coffee
+++ b/lib/controllers/process-controller.coffee
@@ -128,7 +128,6 @@ class ProcessController
       @fields.filePath = "";
       @fields.fileDirPath = "";
       @fields.fileProjectPath = "";
-      @fields.selection = "";
 
     if !@saveDirtyFiles()
       return false;


### PR DESCRIPTION
There doesn't need to be an open file for there to be an active text editor.